### PR TITLE
Bugfix: Correct Java version to 17

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "21"
+          java-version: "71"
 
       - name: Cache tox env
         uses: actions/cache@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "zulu"
-          java-version: "71"
+          java-version: "17"
 
       - name: Cache tox env
         uses: actions/cache@v4


### PR DESCRIPTION
This package relies on Apache Arrow to optimize certain computations via PySpark. However, the current PySpark version is not compatible with Java 21. To resolve this, the Java version has been reverted to 17 to ensure compatibility and avoid runtime issues.